### PR TITLE
Add config-based predictions output

### DIFF
--- a/fmri_processing/utils.py
+++ b/fmri_processing/utils.py
@@ -64,8 +64,15 @@ def load_and_validate_config(config_path: str) -> dict:
         config = safe_load(f)
     
     # Проверка обязательных глобальных полей
-    required_global = ['atlas_path', 'train_model', 'model_path', 
-                      'save_to_numpy', 'features_type', 'func']
+    required_global = [
+        'atlas_path',
+        'train_model',
+        'model_path',
+        'save_to_numpy',
+        'features_type',
+        'func',
+        'results_path',
+    ]
     for key in required_global:
         if key not in config:
             raise KeyError(f"Отсутствует обязательное поле: {key}")
@@ -89,6 +96,11 @@ def load_and_validate_config(config_path: str) -> dict:
         raise ValueError(
             f"Недопустимое значение features_type: {config['features_type']}. "
             f"Допустимые значения: {valid_features}"
+        )
+
+    if not config['results_path']:
+        raise ValueError(
+            "Путь к файлу с результатами (results_path) не может быть пустым"
         )
     
     # Проверка пути к модели

--- a/main.py
+++ b/main.py
@@ -94,7 +94,16 @@ if __name__ == "__main__":
                 most_confident_idx = np.argmax(probabilities[subject_indices]) + i
                 final_predictions[most_confident_idx] = 1
             
-            print("Итоговые предсказания:\n", final_predictions.reshape(-1, 5))
+            predictions_matrix = final_predictions.reshape(-1, 5)
+            print("Итоговые предсказания:\n", predictions_matrix)
+
+            results_path = config['results_path']
+            with open(results_path, 'w') as f:
+                for idx, subject in enumerate(test_subs):
+                    data_file = subject.get('numpy_path') or subject.get('data_path')
+                    preds = predictions_matrix[idx]
+                    f.write(f"{data_file}\n")
+                    f.write(' '.join(map(str, preds.astype(int))) + "\n")
 
     except SystemExit:
         sys.exit(1)

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,7 @@
 data_path: './data/HC/sub-02/denoised_data.nii.gz'  # Путь к fMRI данным в формате .nii.gz
 events_path: './data/HC/sub-02/sub-02_timing.txt'   # Путь к файлу с временным разбиением
 tr: 1.0
+results_path: './results.txt'
 ```
 Файл с временным разбиением должен иметь следующий формат:
 ```

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -4,6 +4,7 @@ model_path: "./models/test_model"
 save_to_numpy: false
 func: "max"
 features_type: "ranks_five"
+results_path: "./results.txt"
 training_dataset:
 - data_path: /home/aaanpilov/diploma/project/data/test_data/1374_Stolbov_A_P/sdenoised_data.nii.gz
   events_path: /home/aaanpilov/diploma/project/data/test_data/1374_Stolbov_A_P/1374


### PR DESCRIPTION
## Summary
- require `results_path` in configuration and validate
- save final predictions to specified file in `main.py`
- document `results_path` in README
- update example `test_config.yaml`

## Testing
- `python -m py_compile main.py fmri_processing/utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6851c8e05c688326886aeafd3b72c049